### PR TITLE
  Add use persisted state hook

### DIFF
--- a/src/hooks/use-persisted-state.ts
+++ b/src/hooks/use-persisted-state.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import isEmpty from "lodash/isEmpty";
+
+export default function usePersistedState<S>(
+  initialState: S,
+  uniqueKey: string
+) {
+  const jsonState = localStorage.getItem(uniqueKey);
+  let state: S;
+  let setState: (state: S) => void;
+
+  try {
+    const persistedState = JSON.parse(jsonState || "{}");
+
+    [state, setState] = useState(
+      isEmpty(persistedState) ? initialState : persistedState
+    );
+  } catch {
+    console.error("Error parsing persisted state: ", jsonState);
+
+    [state, setState] = useState(initialState);
+  }
+
+  useEffect(() => {
+    localStorage.setItem(uniqueKey, JSON.stringify(state));
+  }, [state]);
+
+  return [state, setState];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export * from "src/helpers/ui";
 import * as InputValidationsToExport from "src/helpers/input-validations";
 export const inputValidations = InputValidationsToExport;
 export { default as useMediaQueries } from "src/hooks/useMediaQueries";
+export { default as usePersistedState } from "src/hooks/use-persisted-state";
 
 // Storybook
 import * as StoryCmpts from "./story-helpers";


### PR DESCRIPTION
Added  a `usePersistedState` hook.

It's just a wrapper around Reacts `useState` hook that will persist its state in-between component mounts and browser sessions